### PR TITLE
removed attr_reader and attr_writer for encrypted_attribute_field to fix SVC-18336

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -119,8 +119,6 @@ module AttrEncrypted
       encrypted_attribute_name = (options[:attribute] ? options[:attribute] : [options[:prefix], attribute, options[:suffix]].join).to_sym
 
       instance_methods_as_symbols = instance_methods.collect { |method| method.to_sym }
-      attr_reader encrypted_attribute_name unless instance_methods_as_symbols.include?(encrypted_attribute_name)
-      attr_writer encrypted_attribute_name unless instance_methods_as_symbols.include?(:"#{encrypted_attribute_name}=")
 
       define_method(attribute) do
         instance_variable_get("@#{attribute}") || instance_variable_set("@#{attribute}", decrypt(attribute, send(encrypted_attribute_name)))


### PR DESCRIPTION
This is a fixed for issue null encrypted_private_key value in database (SVC-18336).  The root cause of this issue is given here https://github.com/attr-encrypted/attr_encrypted/issues/26#issue-1074940